### PR TITLE
Remove dur argument when using a fullday event

### DIFF
--- a/src/commands/__test__/startCmd.test.ts
+++ b/src/commands/__test__/startCmd.test.ts
@@ -5,7 +5,7 @@ import { startCmd } from "../startCmd";
 import { switchCmd } from "../switchCmd";
 import { getActiveState } from "../../state/getActiveState";
 import { parseTimeStr } from "../../time/parseTimeStr";
-import { BadDurationError } from "../../errors";
+import { BadDurationError, ExtraDataError } from "../../errors";
 import { toDatumTime } from "../../time/datumTime";
 
 describe("startCmd", () => {
@@ -114,5 +114,10 @@ describe("startCmd", () => {
       state: true,
       req1: "reqVal1",
     });
+  });
+
+  it("fails when using a full day and a duration", async () => {
+    // mistyped -y instead of -t, but does not get mapped to a duration
+    await expect(startCmd("field -y 315")).rejects.toThrow(ExtraDataError);
   });
 });

--- a/src/commands/occurCmd.ts
+++ b/src/commands/occurCmd.ts
@@ -29,7 +29,16 @@ export async function occurCmd(
   preparsed?: Partial<OccurCmdArgs>,
 ): Promise<EitherDocument> {
   args = parseIfNeeded(occurCmdArgs, args, preparsed);
-  const { time: occurTime } = handleTimeArgs(args);
+  const { time: occurTime, onlyDate } = handleTimeArgs(args);
+
+  // if the time is only a date, and duration is one of the keys, remove it to prevent accidental adding of duration to full day events
+  const durKeyIndex =
+    args.keys?.findIndex((key) => key === "dur" || key.startsWith("dur=")) ??
+    -1;
+  if (onlyDate && durKeyIndex !== -1) {
+    args.keys?.splice(durKeyIndex, 1);
+  }
+
   if (occurTime !== undefined) {
     args.cmdData ??= {};
     args.cmdData.occurTime = occurTime;

--- a/src/commands/switchCmd.ts
+++ b/src/commands/switchCmd.ts
@@ -53,6 +53,7 @@ export async function switchCmd(
   preparsed?: Partial<SwitchCmdArgs>,
 ): Promise<EitherDocument> {
   args = parseIfNeeded(switchCmdArgs, args, preparsed);
+
   flexiblePositional(
     args,
     "duration",


### PR DESCRIPTION
When a user mistypes `-y 315` instead of `-t 315`, the document still gets added as a full day event with a duration of 315 minutes, instead of at 3:15. duration doesn't really make sense on full day events anyways, so the dur argument should be elided when a full day event is recorded