### PR TITLE
Raise RepeatedStateError when checking state

### DIFF
--- a/src/state/__test__/__snapshots__/checkState.test.ts.snap
+++ b/src/state/__test__/__snapshots__/checkState.test.ts.snap
@@ -4,10 +4,13 @@ exports[`checkState correctly handles based off of a given startTime and/or endT
 [
   [LastStateError: field 2024-09-05T13:15:00.000Z: lastState does not match actual last state. ids: [field:2024-09-05T13:05:00.000Z, field:2024-09-05T13:15:00.000Z]],
   [OverlappingBlockError: field 2024-09-05T14:00:00.000Z: State changes within a block. ids: [field:2024-09-05T14:05:00.000Z, field:2024-09-05T14:00:00.000Z ]}],
+  [RepeatedStateError: field 2024-09-05T15:10:00.000Z: state "repeatedState" is repeated. ids: [field:2024-09-05T15:00:00.000Z, field:2024-09-05T15:10:00.000Z]],
 ]
 `;
 
 exports[`checkState throws a LastStateError if lastState does not reflect the last state correctly 1`] = `[LastStateError: field 2024-09-05T10:20:00.000Z: lastState does not match actual last state. ids: [field:2024-09-05T10:15:00.000Z, field:2024-09-05T10:20:00.000Z]]`;
+
+exports[`checkState throws a RepeatedStateError if the same state is repeated 1`] = `[RepeatedStateError: field 2024-09-05T10:20:00.000Z: state "state1" is repeated. ids: [field:2024-09-05T10:15:00.000Z, field:2024-09-05T10:20:00.000Z]]`;
 
 exports[`checkState throws an OverlappingBlockError if a state change block is inserted and overlaps another state change 1`] = `
 [

--- a/src/state/__test__/checkState.test.ts
+++ b/src/state/__test__/checkState.test.ts
@@ -62,6 +62,8 @@ describe("checkState", () => {
     expect(errors.errors[0]).toMatchSnapshot();
   });
 
+  it("throws a StateChange error if ")
+
   it("throws an OverlappingBlockError if a state change block is inserted and overlaps another state change", async () => {
     setNow("10:45");
     await switchCmd("project emails");

--- a/src/state/checkState.ts
+++ b/src/state/checkState.ts
@@ -128,7 +128,7 @@ export async function checkState({
         if (isEqual(thisRow.value[0], thisRow.value[1])) {
           const occurTime = thisRow.key[1];
           const problem = `state ${JSON.stringify(thisRow.value[0])} is repeated`;
-          const error = new StateChangeError({
+          const error = new RepeatedStateError({
             message: `${field} ${occurTime}: ${problem}. ids: [${previousRow.id}, ${thisRow.id}]`,
             ids: [previousRow.id, thisRow.id],
             occurTime: thisRow.key[1],

--- a/src/state/checkState.ts
+++ b/src/state/checkState.ts
@@ -118,6 +118,23 @@ export async function checkState({
       const previousRow = i === 0 ? initialRow : stateChangeRows[i - 1];
       const thisRow = stateChangeRows[i];
       if (isEqual(previousRow.value[1], thisRow.value[0])) {
+        // if state does not change at all, then also an error
+        if (isEqual(thisRow.value[0], thisRow.value[1])) {
+          const occurTime = thisRow.key[1];
+          const problem = "State does not change";
+          const error = new StateChangeError({
+            message: `${field} ${occurTime}: ${problem}. ids: [${previousRow.id}, ${thisRow.id}]`,
+            ids: [previousRow.id, thisRow.id],
+            occurTime: thisRow.key[1],
+            field,
+          });
+          if (failOnError) {
+            throw error;
+          } else {
+            summary.ok = false;
+            summary.errors.push(error);
+          }
+        }
         continue processRowsLoop;
       }
       // use the block times view to determine if two blocks are overlapping or a block is overlapping with a state change

--- a/src/state/checkState.ts
+++ b/src/state/checkState.ts
@@ -43,6 +43,12 @@ export class LastStateError extends StateChangeError {
     Object.setPrototypeOf(this, LastStateError.prototype);
   }
 }
+export class RepeatedStateError extends StateChangeError {
+  constructor(args: StateChangeErrorType) {
+    super(args);
+    Object.setPrototypeOf(this, RepeatedStateError.prototype);
+  }
+}
 
 export class OverlappingBlockError extends StateChangeError {
   constructor(args: StateChangeErrorType) {
@@ -121,7 +127,7 @@ export async function checkState({
         // if state does not change at all, then also an error
         if (isEqual(thisRow.value[0], thisRow.value[1])) {
           const occurTime = thisRow.key[1];
-          const problem = "State does not change";
+          const problem = `state ${JSON.stringify(thisRow.value[0])} is repeated`;
           const error = new StateChangeError({
             message: `${field} ${occurTime}: ${problem}. ids: [${previousRow.id}, ${thisRow.id}]`,
             ids: [previousRow.id, thisRow.id],

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -37,14 +37,14 @@ export function getContrastTextColor(
   switch (messageType) {
     case "warning":
       // Use darker yellow if background is bright or yellowish
-      if (isBright || (bgR > 200 && bgG > 200)) {
-        return "#8B8000"; // Dark yellow
+      if (bgR > 200 && bgG > 200) {
+        return "#bB8000"; // Yellow orange
       }
       return "#FFD700"; // Bright yellow
 
     case "error":
       // Use darker red if background is bright or reddish
-      if (isBright || bgR > 200) {
+      if (bgR > 200) {
         return "#8B0000"; // Dark red
       }
       return "#FF0000"; // Bright red


### PR DESCRIPTION
It is useful to not allow repeated states because that often indicates that some datum was missed. now checkCmd detects repetaed states. This will also appear on dayview