### PR TITLE
prevent get command from getting tripped on space on id

### DIFF
--- a/src/migrations/interactiveMigration.ts
+++ b/src/migrations/interactiveMigration.ts
@@ -34,7 +34,7 @@ export async function interactiveMigration({
       value: { op, data },
     } = row;
     console.info("----------------------");
-    await getCmd(row.id, outputArgs);
+    await getCmd([row.id], outputArgs);
     console.info(chalk.cyan(`~~~~ OP: ${op} ~~~~`));
     console.info(stringify(data));
     console.info("----------------------");


### PR DESCRIPTION
When doing an interactive migration, space in the id would cause the getCmd to fail. This fixes that bug