### PR TITLE
Allow matching ids with commas in them with quickId

### DIFF
--- a/src/ids/__test__/quickId.test.ts
+++ b/src/ids/__test__/quickId.test.ts
@@ -251,4 +251,22 @@ describe("quickId", () => {
       expect(e).toBeInstanceOf(AmbiguousQuickIdError);
     }
   });
+
+  it("prefers an id match with commas over splitting by commas", async () => {
+    await db.put({
+      _id: "id1,ghi,and more",
+      meta: { humanId: "abc" },
+    });
+    await db.put({
+      _id: "id1",
+      meta: { humanId: "ghi" },
+    });
+    await db.put({
+      _id: "id2",
+      meta: { humanId: "jkl" },
+    });
+    expect(await quickId("id1,ghi,and more", {})).toEqual(["id1,ghi,and more"]);
+    expect(await quickId("id1,ghi", {})).toEqual(["id1,ghi,and more"]);
+    expect(await quickId("id1,jkl", {})).toEqual(["id1", "id2"]);
+  });
 });

--- a/src/ids/quickId.ts
+++ b/src/ids/quickId.ts
@@ -237,29 +237,9 @@ export async function quickId(
     }
   }
 
-  const idPromises = quickArray.map(async (str) => {
-    const special = await specialQuickId(str, db);
-    if (special.length > 0) {
-      return special;
-    }
-    const exact = await exactId(str, db);
-    if (exact) {
-      return exact;
-    }
-    const matchesHumanId = await startsHumanId(
-      str,
-      db,
-      args.onAmbiguousQuickId,
-    );
-    if (matchesHumanId.length > 0) {
-      return matchesHumanId;
-    }
-    const matchesMainId = await startsMainId(str, db, args.onAmbiguousQuickId);
-    if (matchesMainId.length > 0) {
-      return matchesMainId;
-    }
-    throw new NoQuickIdMatchError(str);
-  });
+  const idPromises = quickArray.map(async (str) =>
+    searchForQuickId(str, db, args.onAmbiguousQuickId),
+  );
 
   return (await Promise.all(idPromises)).flat();
 }


### PR DESCRIPTION
Quick id splits by comma to match multiple, but sometimes an id might have commas in them. This PR has quickId first check if the comma version can be found