### PR TITLE
Change address to have a nonzero height

### DIFF
--- a/src/field/mySpecs.ts
+++ b/src/field/mySpecs.ts
@@ -15,7 +15,7 @@ export const FIELD_SPECS: Record<string, FieldSpec> = {
   address: {
     kind: "switch",
     y: 0,
-    height: 0,
+    height: 0.001, // TODO: make this 0 once all bugs are worked out (inkscape transfroms svg in a weird way to png with 0 height blocks)
   },
   country: {
     kind: "switch",
@@ -110,7 +110,7 @@ export const FIELD_SPECS: Record<string, FieldSpec> = {
   },
   pee: {
     kind: "occur",
-    color: "#eeee00",
+    color: "#bbaa00",
     y: 0.85,
   },
   therapy: {


### PR DESCRIPTION
Inkscape transforms the svg with a 0 height in a weird way when their are multiple days:
![image](https://github.com/user-attachments/assets/585cade6-430e-4277-bc37-6382e960fea7)

for now, just make address nonzero and will deal with this later, when a more robust image creation pipeline is made