### PR TITLE
Don't double trigger test workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push, pull_request_target]
+on: 
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now the push events are only run when main is pushed to