### PR TITLE
Allow field to be composed from other data with % syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Prefer named exports and imports
 - Follow existing directory structure for new files
 - Error handling should be explicit with proper typing
+- When adding new tests or documentation: any date examples should be on today's date as a sort of record of when it was added--purely for style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Error handling should be explicit with proper typing
 - When adding new tests or documentation: any date examples should be on today's date as a sort of record of when it was added--purely for style
 - When removing tests or chunks of code, don't leave a comment behind explaining that something was removed.
+- Use eslint --fix to format after making any changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,4 +25,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Error handling should be explicit with proper typing
 - When adding new tests or documentation: any date examples should be on today's date as a sort of record of when it was added--purely for style
 - When removing tests or chunks of code, don't leave a comment behind explaining that something was removed.
-- Use eslint --fix to format after making any changes
+- Use `pnpm run eslint --fix --max-warnings 0` to format after making any changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Follow existing directory structure for new files
 - Error handling should be explicit with proper typing
 - When adding new tests or documentation: any date examples should be on today's date as a sort of record of when it was added--purely for style
+- When removing tests or chunks of code, don't leave a comment behind explaining that something was removed.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ datum add book title="The Hobbit"  # ID: book:2025-04-14T08:15:00.000Zc  (the "c
 
 ### Composite Fields
 
-You can create composite fields using the `%fieldName%` syntax, which allows fields to be composed from other data:
+You can create composite fields using the `%keyName%` syntax, which allows fields to be composed from other data:
 
 ```bash
 # Create an entry with a composite field from project and task

--- a/README.md
+++ b/README.md
@@ -103,6 +103,48 @@ Datum uses PouchDB by default for local storage. For remote synchronization or m
    - Config file: Update `host:` and credentials
    - CLI: Use the `--host` flag
 
+## Document ID Structure
+
+Datum automatically generates document IDs based on the data you provide. By default, document IDs follow this pattern:
+
+```
+field:value
+```
+
+Where `field` is the field value and `value` is based on the timestamp or other provided data.
+
+### Basic ID Generation
+For standard field values:
+
+```bash
+datum occur sleep     # ID: sleep:2025-04-14T07:30:00.000Z
+datum add book title="The Hobbit"  # ID: book:2025-04-14T08:15:00.000Z
+```
+
+### Composite Fields
+
+You can create composite fields using the `%fieldName%` syntax, which allows fields to be composed from other data:
+
+```bash
+# Create an entry with a composite field from project and task
+datum add field="%project%_%task%" project=website task=homepage
+
+# Entry will have field "website_homepage" and ID: website_homepage:2025-04-14T08:30:00.000Z
+```
+
+### Custom ID Structure
+
+You can customize the ID structure using the `--id` option:
+
+```bash
+# Create an entry with custom ID structure
+datum add book title="The Hobbit" author="J.R.R. Tolkien" --id "%title%_by_%author%"
+
+# ID: book:The Hobbit_by_J.R.R. Tolkien
+```
+
+Composite fields are especially useful for categorizing data hierarchically or creating more descriptive document IDs.
+
 ## Status
 
 ⚠️ Alpha Software Warning: Datum is under active development. Expect breaking changes and instability until version 2.1.0.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can create composite fields using the `%keyName%` syntax, which allows field
 # Create an entry with a composite field from project and task
 datum add field="%project%_%task%" project=website task=homepage
 
-# Entry will have field "website_homepage" and ID: website_homepage:2025-04-14T08:30:00.000Z
+# Entry will have field "website_homepage" and ID: website_homepage:2025-04-14T08:30:00.000Zc
 ```
 
 ### Custom ID Structure

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ datum add book title="The Hobbit" author="J.R.R. Tolkien" --id "%title%_by_%auth
 
 Composite fields are especially useful for categorizing data hierarchically or creating more descriptive document IDs.
 
+> **⚠️ Note:** Field values cannot contain colons (`:`) as they are used as delimiters in document IDs. An error will be thrown if a field contains a colon.
+
 ## Status
 
 ⚠️ Alpha Software Warning: Datum is under active development. Expect breaking changes and instability until version 2.1.0.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For standard field values:
 
 ```bash
 datum occur sleep     # ID: sleep:2025-04-14T07:30:00.000Z
-datum add book title="The Hobbit"  # ID: book:2025-04-14T08:15:00.000Z
+datum add book title="The Hobbit"  # ID: book:2025-04-14T08:15:00.000Zc  (the "c" at the end of the timestamp is for createTime)
 ```
 
 ### Composite Fields

--- a/src/__test__/test-utils.ts
+++ b/src/__test__/test-utils.ts
@@ -171,7 +171,6 @@ export function makeDoc<D extends EitherDocument = EitherDocument>(
       idStructure = buildIdStructure({
         idParts: defaultIdParts,
         delimiter: defaults.idDelimiter,
-        partition: defaultPartitionParts,
       });
     }
     doc._id = assembleId({ payload: doc, idStructure });

--- a/src/__test__/test-utils.ts
+++ b/src/__test__/test-utils.ts
@@ -165,7 +165,7 @@ export function makeDoc<D extends EitherDocument = EitherDocument>(
     if (meta?.idStructure) {
       idStructure = meta.idStructure;
     } else {
-      const { defaultIdParts, defaultPartitionParts } = defaultIdComponents({
+      const { defaultIdParts } = defaultIdComponents({
         data,
       });
       idStructure = buildIdStructure({

--- a/src/commands/__test__/addCmd.test.ts
+++ b/src/commands/__test__/addCmd.test.ts
@@ -104,7 +104,7 @@ describe("addCmd", () => {
       db: db,
       payload: {
         data: { foo: "abc", field: "field" },
-        meta: { idStructure: "%field%:%foo%" },
+        meta: { idStructure: "%foo%" },
       },
     });
   });
@@ -155,7 +155,7 @@ describe("addCmd", () => {
     expect(
       await addCmd("--id rawString --id %foo%!! foo=abc field"),
     ).toMatchObject({
-      meta: { idStructure: "%field%:rawString__%foo%!!" },
+      meta: { idStructure: "rawString__%foo%!!" },
     });
   });
 

--- a/src/commands/__test__/addCmd.test.ts
+++ b/src/commands/__test__/addCmd.test.ts
@@ -118,14 +118,14 @@ describe("addCmd", () => {
     await addCmd("--id 'my name is bob' foo=bar field --show standard");
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("CREATE"));
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("EXISTS"),
+      expect.stringContaining("EXISTS")
     );
 
     mockedLog.mockReset();
 
     await addCmd("--id 'my name is bob' foo=bar field --show standard");
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("CREATE"),
+      expect.stringContaining("CREATE")
     );
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("EXISTS"));
   });
@@ -134,14 +134,14 @@ describe("addCmd", () => {
     await addCmd("--id 'my name is doug' foo=bar field --show standard");
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("CREATE"));
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("EXISTS"),
+      expect.stringContaining("EXISTS")
     );
 
     mockedLog.mockReset();
 
     try {
       await addCmd(
-        "--id 'my name is doug' different=data field --show standard",
+        "--id 'my name is doug' different=data field --show standard"
       );
       fail();
     } catch (e) {
@@ -153,7 +153,7 @@ describe("addCmd", () => {
 
   it("inserts id structure into the metadata", async () => {
     expect(
-      await addCmd("--id rawString --id %foo%!! foo=abc field"),
+      await addCmd("--id rawString --id %foo%!! foo=abc field")
     ).toMatchObject({
       meta: { idStructure: "rawString__%foo%!!" },
     });
@@ -161,7 +161,7 @@ describe("addCmd", () => {
 
   it("can use custom base data", async () => {
     expect(
-      await addCmd('-b "{a: 1, b:2, c:3 }" field --id "basedata-doc1"'),
+      await addCmd('-b "{a: 1, b:2, c:3 }" field --id "basedata-doc1"')
     ).toMatchObject({
       data: { a: 1, b: 2, c: 3, field: "field" },
       _id: "field:basedata-doc1",
@@ -170,7 +170,7 @@ describe("addCmd", () => {
 
   it("can write payloads directly by specifying base-data no-metadata and fieldless", async () => {
     expect(
-      await addCmd("-FM -b '{a: 1, b:2, c:3 }' --id basedata-doc2"),
+      await addCmd("-FM -b '{a: 1, b:2, c:3 }' --id basedata-doc2")
     ).toEqual({
       _id: "basedata-doc2",
       _rev: expect.any(String),
@@ -182,16 +182,16 @@ describe("addCmd", () => {
 
   it("throws a BaseDataError if baseData is malformed", async () => {
     await expect(addCmd("-F -b 'string_is_not_good_basedata'")).rejects.toThrow(
-      BaseDataError,
+      BaseDataError
     );
   });
 
   it("prefers the _id specified when in no-metadata mode", async () => {
     expect(
-      await addCmd("-FM -b '{_id: payload-id}' --id argument-id"),
+      await addCmd("-FM -b '{_id: payload-id}' --id argument-id")
     ).toMatchObject({ _id: "payload-id" });
     expect(
-      await addCmd("-FM -b '{_id: payload-id-2}' --id '%keyId%' keyId=key-id"),
+      await addCmd("-FM -b '{_id: payload-id-2}' --id '%keyId%' keyId=key-id")
     ).toMatchObject({ _id: "payload-id-2" });
     expect(await addCmd("-FM --id 'idPart-id' _id=posArgs-id")).toMatchObject({
       _id: "posArgs-id",
@@ -209,21 +209,21 @@ describe("addCmd", () => {
       /^(?=[\s\S]*_id:)(?=[\s\S]*data:)(?=[\s\S]*meta:)/;
     await addCmd("field --id this-id"); //note when called in tests like this show is "none" by default. From the main entrypoint it is "standard"
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder),
+      expect.stringMatching(matchExtraKeysInAnyOrder)
     );
 
     mockedLog.mockClear();
 
     await addCmd("field --id that-id --show-all");
     expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder),
+      expect.stringMatching(matchExtraKeysInAnyOrder)
     );
 
     mockedLog.mockClear();
 
     await addCmd("field --id short-show-all -A");
     expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder),
+      expect.stringMatching(matchExtraKeysInAnyOrder)
     );
   });
 
@@ -246,18 +246,18 @@ describe("addCmd", () => {
   it("correctly displays interpolated field values in output", async () => {
     mockedLog.mockClear();
     await addCmd(
-      "%project%_%activity% project=Testing activity=Fields --show standard",
+      "%project%_%activity% project=Testing activity=Fields --show standard"
     );
-    expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringContaining("Testing_Fields"),
+    expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
+      `"Testing_Fields ¢"`
     );
 
     mockedLog.mockClear();
     await addCmd(
-      "%project%-%name% project=Composite name=Test --show standard",
+      "%project%-%name% project=Composite name=Test --show standard"
     );
-    expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringContaining("Composite-Test"),
+    expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
+      `"Composite-Test ¢"`
     );
   });
 });

--- a/src/commands/__test__/addCmd.test.ts
+++ b/src/commands/__test__/addCmd.test.ts
@@ -242,4 +242,14 @@ describe("addCmd", () => {
     expect(addDocSpy.mock.calls[1][0].conflictStrategy).toEqual("update");
     expect(newDoc).toMatchObject({ data: { foo: "def" } });
   });
+
+  it("correctly displays interpolated field values in output", async () => {
+    mockedLog.mockClear();
+    await addCmd("%project%_%activity% project=Testing activity=Fields --show standard");
+    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Testing_Fields"));
+    
+    mockedLog.mockClear();
+    await addCmd("%project%-%name% project=Composite name=Test --show standard");
+    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Composite-Test"));
+  });
 });

--- a/src/commands/__test__/addCmd.test.ts
+++ b/src/commands/__test__/addCmd.test.ts
@@ -118,14 +118,14 @@ describe("addCmd", () => {
     await addCmd("--id 'my name is bob' foo=bar field --show standard");
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("CREATE"));
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("EXISTS")
+      expect.stringContaining("EXISTS"),
     );
 
     mockedLog.mockReset();
 
     await addCmd("--id 'my name is bob' foo=bar field --show standard");
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("CREATE")
+      expect.stringContaining("CREATE"),
     );
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("EXISTS"));
   });
@@ -134,14 +134,14 @@ describe("addCmd", () => {
     await addCmd("--id 'my name is doug' foo=bar field --show standard");
     expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("CREATE"));
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("EXISTS")
+      expect.stringContaining("EXISTS"),
     );
 
     mockedLog.mockReset();
 
     try {
       await addCmd(
-        "--id 'my name is doug' different=data field --show standard"
+        "--id 'my name is doug' different=data field --show standard",
       );
       fail();
     } catch (e) {
@@ -153,7 +153,7 @@ describe("addCmd", () => {
 
   it("inserts id structure into the metadata", async () => {
     expect(
-      await addCmd("--id rawString --id %foo%!! foo=abc field")
+      await addCmd("--id rawString --id %foo%!! foo=abc field"),
     ).toMatchObject({
       meta: { idStructure: "rawString__%foo%!!" },
     });
@@ -161,7 +161,7 @@ describe("addCmd", () => {
 
   it("can use custom base data", async () => {
     expect(
-      await addCmd('-b "{a: 1, b:2, c:3 }" field --id "basedata-doc1"')
+      await addCmd('-b "{a: 1, b:2, c:3 }" field --id "basedata-doc1"'),
     ).toMatchObject({
       data: { a: 1, b: 2, c: 3, field: "field" },
       _id: "field:basedata-doc1",
@@ -170,7 +170,7 @@ describe("addCmd", () => {
 
   it("can write payloads directly by specifying base-data no-metadata and fieldless", async () => {
     expect(
-      await addCmd("-FM -b '{a: 1, b:2, c:3 }' --id basedata-doc2")
+      await addCmd("-FM -b '{a: 1, b:2, c:3 }' --id basedata-doc2"),
     ).toEqual({
       _id: "basedata-doc2",
       _rev: expect.any(String),
@@ -182,16 +182,16 @@ describe("addCmd", () => {
 
   it("throws a BaseDataError if baseData is malformed", async () => {
     await expect(addCmd("-F -b 'string_is_not_good_basedata'")).rejects.toThrow(
-      BaseDataError
+      BaseDataError,
     );
   });
 
   it("prefers the _id specified when in no-metadata mode", async () => {
     expect(
-      await addCmd("-FM -b '{_id: payload-id}' --id argument-id")
+      await addCmd("-FM -b '{_id: payload-id}' --id argument-id"),
     ).toMatchObject({ _id: "payload-id" });
     expect(
-      await addCmd("-FM -b '{_id: payload-id-2}' --id '%keyId%' keyId=key-id")
+      await addCmd("-FM -b '{_id: payload-id-2}' --id '%keyId%' keyId=key-id"),
     ).toMatchObject({ _id: "payload-id-2" });
     expect(await addCmd("-FM --id 'idPart-id' _id=posArgs-id")).toMatchObject({
       _id: "posArgs-id",
@@ -209,21 +209,21 @@ describe("addCmd", () => {
       /^(?=[\s\S]*_id:)(?=[\s\S]*data:)(?=[\s\S]*meta:)/;
     await addCmd("field --id this-id"); //note when called in tests like this show is "none" by default. From the main entrypoint it is "standard"
     expect(mockedLog).not.toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder)
+      expect.stringMatching(matchExtraKeysInAnyOrder),
     );
 
     mockedLog.mockClear();
 
     await addCmd("field --id that-id --show-all");
     expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder)
+      expect.stringMatching(matchExtraKeysInAnyOrder),
     );
 
     mockedLog.mockClear();
 
     await addCmd("field --id short-show-all -A");
     expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringMatching(matchExtraKeysInAnyOrder)
+      expect.stringMatching(matchExtraKeysInAnyOrder),
     );
   });
 
@@ -246,18 +246,18 @@ describe("addCmd", () => {
   it("correctly displays interpolated field values in output", async () => {
     mockedLog.mockClear();
     await addCmd(
-      "%project%_%activity% project=Testing activity=Fields --show standard"
+      "%project%_%activity% project=Testing activity=Fields --show standard",
     );
     expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"Testing_Fields ¢"`
+      `"Testing_Fields ¢"`,
     );
 
     mockedLog.mockClear();
     await addCmd(
-      "%project%-%name% project=Composite name=Test --show standard"
+      "%project%-%name% project=Composite name=Test --show standard",
     );
     expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"Composite-Test ¢"`
+      `"Composite-Test ¢"`,
     );
   });
 });

--- a/src/commands/__test__/addCmd.test.ts
+++ b/src/commands/__test__/addCmd.test.ts
@@ -245,11 +245,19 @@ describe("addCmd", () => {
 
   it("correctly displays interpolated field values in output", async () => {
     mockedLog.mockClear();
-    await addCmd("%project%_%activity% project=Testing activity=Fields --show standard");
-    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Testing_Fields"));
-    
+    await addCmd(
+      "%project%_%activity% project=Testing activity=Fields --show standard",
+    );
+    expect(mockedLog).toHaveBeenCalledWith(
+      expect.stringContaining("Testing_Fields"),
+    );
+
     mockedLog.mockClear();
-    await addCmd("%project%-%name% project=Composite name=Test --show standard");
-    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Composite-Test"));
+    await addCmd(
+      "%project%-%name% project=Composite name=Test --show standard",
+    );
+    expect(mockedLog).toHaveBeenCalledWith(
+      expect.stringContaining("Composite-Test"),
+    );
   });
 });

--- a/src/commands/__test__/occurCmd.test.ts
+++ b/src/commands/__test__/occurCmd.test.ts
@@ -43,18 +43,18 @@ describe("occurCmd", () => {
 
   it("stores the occurTime in the data", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2021-08-23 -t 12 -z 0"
+      "event -d 2021-08-23 -t 12 -z 0",
     )) as DatumDocument;
     expect(newDoc.data).toHaveProperty(
       "occurTime.utc",
-      "2021-08-23T12:00:00.000Z"
+      "2021-08-23T12:00:00.000Z",
     );
     expect(newDoc.meta).not.toHaveProperty("occurTime");
   });
 
   it("stores the occurTime in DataOnly docs", async () => {
     const newDoc = (await occurCmd(
-      "event -M -d 2021-08-23 -t 12 -z 0"
+      "event -M -d 2021-08-23 -t 12 -z 0",
     )) as DatumDocument;
     expect(newDoc).toHaveProperty("occurTime.utc", "2021-08-23T12:00:00.000Z");
     expect(newDoc).toHaveProperty("occurTime.o", 0);
@@ -62,7 +62,7 @@ describe("occurCmd", () => {
 
   it("stores offset", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2021-08-23 -t 12 -z +3"
+      "event -d 2021-08-23 -t 12 -z +3",
     )) as DatumDocument;
     expect(newDoc.data).toMatchObject({
       occurTime: {
@@ -74,7 +74,7 @@ describe("occurCmd", () => {
 
   it("stores offset from an IANA timezone", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2023-12-04 -t 12 -z Europe/Berlin"
+      "event -d 2023-12-04 -t 12 -z Europe/Berlin",
     )) as DatumDocument;
     expect(newDoc.data).toMatchObject({
       occurTime: {
@@ -126,17 +126,17 @@ describe("occurCmd", () => {
     // Test with composite field using one data value
     await occurCmd("%task% task=Testing --show standard");
     expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"13:30:00+0 Testing ●"`
+      `"13:30:00+0 Testing ●"`,
     );
 
     mockedLog.mockClear();
 
     // Test with composite field using multiple data values
     await occurCmd(
-      "%project%-%task% project=Output task=Interpolation --show standard"
+      "%project%-%task% project=Output task=Interpolation --show standard",
     );
     expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"13:30:00+0 Output-Interpolation ●"`
+      `"13:30:00+0 Output-Interpolation ●"`,
     );
 
     popNow();

--- a/src/commands/__test__/occurCmd.test.ts
+++ b/src/commands/__test__/occurCmd.test.ts
@@ -43,18 +43,18 @@ describe("occurCmd", () => {
 
   it("stores the occurTime in the data", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2021-08-23 -t 12 -z 0",
+      "event -d 2021-08-23 -t 12 -z 0"
     )) as DatumDocument;
     expect(newDoc.data).toHaveProperty(
       "occurTime.utc",
-      "2021-08-23T12:00:00.000Z",
+      "2021-08-23T12:00:00.000Z"
     );
     expect(newDoc.meta).not.toHaveProperty("occurTime");
   });
 
   it("stores the occurTime in DataOnly docs", async () => {
     const newDoc = (await occurCmd(
-      "event -M -d 2021-08-23 -t 12 -z 0",
+      "event -M -d 2021-08-23 -t 12 -z 0"
     )) as DatumDocument;
     expect(newDoc).toHaveProperty("occurTime.utc", "2021-08-23T12:00:00.000Z");
     expect(newDoc).toHaveProperty("occurTime.o", 0);
@@ -62,7 +62,7 @@ describe("occurCmd", () => {
 
   it("stores offset", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2021-08-23 -t 12 -z +3",
+      "event -d 2021-08-23 -t 12 -z +3"
     )) as DatumDocument;
     expect(newDoc.data).toMatchObject({
       occurTime: {
@@ -74,7 +74,7 @@ describe("occurCmd", () => {
 
   it("stores offset from an IANA timezone", async () => {
     const newDoc = (await occurCmd(
-      "event -d 2023-12-04 -t 12 -z Europe/Berlin",
+      "event -d 2023-12-04 -t 12 -z Europe/Berlin"
     )) as DatumDocument;
     expect(newDoc.data).toMatchObject({
       occurTime: {
@@ -125,16 +125,18 @@ describe("occurCmd", () => {
 
     // Test with composite field using one data value
     await occurCmd("%task% task=Testing --show standard");
-    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Testing"));
+    expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
+      `"13:30:00+0 Testing ●"`
+    );
 
     mockedLog.mockClear();
 
     // Test with composite field using multiple data values
     await occurCmd(
-      "%project%-%task% project=Output task=Interpolation --show standard",
+      "%project%-%task% project=Output task=Interpolation --show standard"
     );
-    expect(mockedLog).toHaveBeenCalledWith(
-      expect.stringContaining("Output-Interpolation"),
+    expect(mockedLog.mock.calls[1][0]).toMatchInlineSnapshot(
+      `"13:30:00+0 Output-Interpolation ●"`
     );
 
     popNow();

--- a/src/commands/__test__/occurCmd.test.ts
+++ b/src/commands/__test__/occurCmd.test.ts
@@ -1,4 +1,5 @@
 import {
+  mockedLogLifecycle,
   popNow,
   pushNow,
   restoreNow,
@@ -13,6 +14,7 @@ import { getActiveState } from "../../state/getActiveState";
 describe("occurCmd", () => {
   const dbName = "occur_cmd_test";
   const db = testDbLifecycle(dbName);
+  const { mockedLog } = mockedLogLifecycle();
 
   beforeEach(async () => {
     await setupCmd("");
@@ -115,5 +117,26 @@ describe("occurCmd", () => {
     expect(newDoc2.data.occurTime).toMatchObject({
       utc: "2024-04-23",
     });
+  });
+
+  it("correctly displays interpolated field values in output", async () => {
+    pushNow("2025-04-14,13:30");
+    mockedLog.mockClear();
+
+    // Test with composite field using one data value
+    await occurCmd("%task% task=Testing --show standard");
+    expect(mockedLog).toHaveBeenCalledWith(expect.stringContaining("Testing"));
+
+    mockedLog.mockClear();
+
+    // Test with composite field using multiple data values
+    await occurCmd(
+      "%project%-%task% project=Output task=Interpolation --show standard",
+    );
+    expect(mockedLog).toHaveBeenCalledWith(
+      expect.stringContaining("Output-Interpolation"),
+    );
+
+    popNow();
   });
 });

--- a/src/commands/addCmd.ts
+++ b/src/commands/addCmd.ts
@@ -37,13 +37,6 @@ newDocArgs.add_argument("--id-part", "--id", {
 newDocArgs.add_argument("--id-delimiter", {
   help: "spacer between fields in the id",
 });
-newDocArgs.add_argument("--partition", "-P", {
-  help:
-    "field to use for the partition (default: field, specified with -f)." +
-    " Can be fields of data or raw strings surrounded by single quotes." +
-    " Like --id-part, can be used  multiple times to assemble a partition separated by --id-delimiter",
-  action: "append",
-});
 newDocArgs.add_argument("--undo", "-u", {
   help: "undoes the last datum entry",
   action: "store_true",
@@ -84,7 +77,6 @@ export type AddCmdArgs = MainDatumArgs &
     noMetadata?: boolean;
     idParts?: string[];
     idDelimiter?: string;
-    partition?: string;
     undo?: boolean;
     forceUndo?: boolean;
     merge?: boolean;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -181,3 +181,10 @@ export class LastDocsTooOldError extends MyError {
     Object.setPrototypeOf(this, LastDocsTooOldError.prototype);
   }
 }
+
+export class FieldError extends MyError {
+  constructor(m: unknown) {
+    super(m);
+    Object.setPrototypeOf(this, FieldError.prototype);
+  }
+}

--- a/src/ids/__test__/defaultIdComponents.test.ts
+++ b/src/ids/__test__/defaultIdComponents.test.ts
@@ -30,49 +30,4 @@ describe("defaultIdComponents", () => {
       defaultIdParts: ["%firstKey%", "%secondKey%"],
     });
   });
-
-  it("uses field as the default partition", () => {
-    expect(
-      defaultIdComponents({
-        data: { field: "abc", occurTime: { utc: exampleOccurTime } },
-      }),
-    ).toMatchObject({
-      defaultPartitionParts: ["%field%"],
-    });
-    expect(defaultIdComponents({ data: { field: "abc" } })).toMatchObject({
-      defaultPartitionParts: ["%field%"],
-    });
-    expect(
-      defaultIdComponents({
-        data: {
-          field: "works",
-          with: "other",
-          keys: "too",
-          occurTime: { utc: exampleOccurTime },
-        },
-      }),
-    ).toMatchObject({ defaultPartitionParts: ["%field%"] });
-    expect(
-      defaultIdComponents({
-        data: { field: "works", with: "other", keys: "too" },
-      }),
-    ).toMatchObject({ defaultPartitionParts: ["%field%"] });
-  });
-
-  it("returns undefined for defaultPartitionParts when no field is present", () => {
-    expect(
-      defaultIdComponents({
-        data: {
-          no: "field",
-          key: "present",
-          occurTime: { utc: exampleOccurTime },
-        },
-      }),
-    ).toMatchObject({ defaultPartitionParts: undefined });
-    expect(
-      defaultIdComponents({
-        data: { no: "field", key: "present" },
-      }),
-    ).toMatchObject({ defaultPartitionParts: undefined });
-  });
 });

--- a/src/ids/__test__/fullIdFlow.test.ts
+++ b/src/ids/__test__/fullIdFlow.test.ts
@@ -31,7 +31,6 @@ function expectStructureAndId(
 
   const buildIdStructureProps: buildIdStructureType = {
     idParts: props.idParts ?? defaultIdParts,
-    partition: props.partition ?? defaultPartitionParts,
     delimiter: props.delimiter,
   };
   const idStructure = buildIdStructure(buildIdStructureProps);
@@ -189,12 +188,10 @@ describe("id flow", () => {
       "main:" + exampleOccurTime,
       exampleDataOccurField,
     );
-    expectStructureAndId(
-      { idParts: "%foo" },
-      "%foo%",
-      "otherName:abc",
-      { ...exampleData, field: "otherName" },
-    );
+    expectStructureAndId({ idParts: "%foo" }, "%foo%", "otherName:abc", {
+      ...exampleData,
+      field: "otherName",
+    });
   });
 
   it("handles this example", () => {

--- a/src/ids/__test__/fullIdFlow.test.ts
+++ b/src/ids/__test__/fullIdFlow.test.ts
@@ -22,7 +22,7 @@ function expectStructureAndId(
   testData: DatumData = exampleData,
   testMeta: DatumMetadata | false = exampleMeta,
 ) {
-  const { defaultPartitionParts, defaultIdParts } = defaultIdComponents({
+  const { defaultIdParts } = defaultIdComponents({
     data: testData,
   });
   const payload: EitherPayload = testMeta

--- a/src/ids/__test__/fullIdFlow.test.ts
+++ b/src/ids/__test__/fullIdFlow.test.ts
@@ -192,6 +192,15 @@ describe("id flow", () => {
       ...exampleData,
       field: "otherName",
     });
+    expectStructureAndId(
+      { idParts: "%field" },
+      "%field%",
+      "onlyField:onlyField",
+      {
+        field: "onlyField",
+      },
+      false,
+    );
   });
 
   it("handles this example", () => {
@@ -201,8 +210,12 @@ describe("id flow", () => {
         delimiter: "__",
       },
       "%foo%__%?modifyTime%__rawString",
-      "main:abc__2020-11-09T00:40:12.544Z__rawString",
-      exampleDataOccurField,
+      "multipart_field:abc__2020-11-09T00:40:12.544Z__rawString",
+      {
+        ...exampleDataOccur,
+        composite: "multipart",
+        field: "%composite%_field",
+      },
     );
   });
 

--- a/src/ids/__test__/fullIdFlow.test.ts
+++ b/src/ids/__test__/fullIdFlow.test.ts
@@ -182,59 +182,18 @@ describe("id flow", () => {
     expectStructureAndId({ idParts: "%wei\\%rd" }, "%wei\\%rd%", "da%ta");
   });
 
-  it("prepends the partition field if provided", () => {
+  it("uses field as partition", () => {
     expectStructureAndId(
       {},
-      "%field%:%occurTime%",
+      "%occurTime%",
       "main:" + exampleOccurTime,
       exampleDataOccurField,
     );
     expectStructureAndId(
       { idParts: "%foo" },
-      "%field%:%foo%",
+      "%foo%",
       "otherName:abc",
       { ...exampleData, field: "otherName" },
-    );
-    expectStructureAndId(
-      {},
-      "%field%:%field%",
-      "onlyField:onlyField",
-      {
-        field: "onlyField",
-      },
-      false,
-    );
-  });
-
-  it("can use other fields, strings, and combinations as partition", () => {
-    expectStructureAndId(
-      { partition: "%foo", idParts: "%bar" },
-      "%foo%:%bar%",
-      "abc:def",
-    );
-    expectStructureAndId(
-      { partition: "%bar", idParts: "%bar" },
-      "%bar%:%bar%",
-      "def:def",
-    );
-    expectStructureAndId(
-      { partition: "rawString", idParts: ["%foo", "raw"] },
-      "rawString:%foo%__raw",
-      "rawString:abc__raw",
-    );
-    expectStructureAndId(
-      { partition: ["%foo", "%bar%-with-extra"], idParts: "id" },
-      "%foo%__%bar%-with-extra:id",
-      "abc__def-with-extra:id",
-    );
-    expectStructureAndId(
-      {
-        partition: ["%foo", "%bar"],
-        idParts: ["some", "strings"],
-        delimiter: "!",
-      },
-      "%foo%!%bar%:some!strings",
-      "abc!def:some!strings",
     );
   });
 
@@ -243,9 +202,8 @@ describe("id flow", () => {
       {
         idParts: ["%foo", "%?modifyTime", "rawString"],
         delimiter: "__",
-        partition: "%field",
       },
-      "%field%:%foo%__%?modifyTime%__rawString",
+      "%foo%__%?modifyTime%__rawString",
       "main:abc__2020-11-09T00:40:12.544Z__rawString",
       exampleDataOccurField,
     );
@@ -274,17 +232,6 @@ describe("id flow", () => {
       {
         "?modifyTime": "now",
       },
-    );
-  });
-
-  it("can use metadata fields in the partition", () => {
-    expectStructureAndId(
-      {
-        idParts: "%foo",
-        partition: "%?humanId",
-      },
-      "%?humanId%:%foo%",
-      "mqp4znq4cvp3qnj74fgi9:abc",
     );
   });
 

--- a/src/ids/__test__/fullIdFlow.test.ts
+++ b/src/ids/__test__/fullIdFlow.test.ts
@@ -234,6 +234,17 @@ describe("id flow", () => {
     );
   });
 
+  it("can use metadata fields in the field partition", () => {
+    expectStructureAndId(
+      {
+        idParts: "%foo",
+      },
+      "%foo%",
+      "mqp4znq4cvp3qnj74fgi9:abc",
+      { ...exampleData, field: "%?humanId%" },
+    );
+  });
+
   it("can use a dataField that starts with a question mark by escaping the question", () => {
     expectStructureAndId(
       { idParts: "%\\?modifyTime%" },

--- a/src/ids/assembleId.ts
+++ b/src/ids/assembleId.ts
@@ -43,5 +43,18 @@ export const assembleId = function ({
     throw new IdError("Cannot determine the id");
   }
 
-  return interpolateFields({ data, meta, format: structure });
+  // Generate the main part of the ID
+  const mainId = interpolateFields({ data, meta, format: structure });
+  
+  // Add field partition if available
+  if ("field" in data && data.field) {
+    // Check if the ID already starts with field: (to avoid double field prefixing)
+    if (mainId.startsWith(`${data.field}:`)) {
+      return mainId;
+    }
+    const partition = interpolateFields({ data, meta, format: String(data.field) });
+    return `${partition}:${mainId}`;
+  }
+  
+  return mainId;
 };

--- a/src/ids/assembleId.ts
+++ b/src/ids/assembleId.ts
@@ -34,28 +34,29 @@ export const assembleId = function ({
     throw new IdError("idStructure in meta and argument do not match");
   }
 
-  const structure = idStructure ?? meta?.idStructure;
+  idStructure ??= meta?.idStructure;
 
-  if (structure === undefined) {
+  if (idStructure === undefined) {
     if (payload._id !== undefined) {
       return payload._id;
     }
     throw new IdError("Cannot determine the id");
   }
 
+  // For backwards compatibility, check if the id structure already starts with field: (to avoid double field prefixing)
+  if (idStructure.startsWith("field:")) {
+    idStructure = idStructure.slice(6);
+  }
+
   // Generate the main part of the ID
-  const mainId = interpolateFields({ data, meta, format: structure });
+  const mainId = interpolateFields({ data, meta, format: idStructure });
 
   // Add field partition if available
   if ("field" in data && data.field) {
-    // Check if the ID already starts with field: (to avoid double field prefixing)
-    if (mainId.startsWith(`${data.field}:`)) {
-      return mainId;
-    }
     const partition = interpolateFields({
       data,
       meta,
-      format: String(data.field),
+      format: data.field,
     });
     return `${partition}:${mainId}`;
   }

--- a/src/ids/assembleId.ts
+++ b/src/ids/assembleId.ts
@@ -45,16 +45,20 @@ export const assembleId = function ({
 
   // Generate the main part of the ID
   const mainId = interpolateFields({ data, meta, format: structure });
-  
+
   // Add field partition if available
   if ("field" in data && data.field) {
     // Check if the ID already starts with field: (to avoid double field prefixing)
     if (mainId.startsWith(`${data.field}:`)) {
       return mainId;
     }
-    const partition = interpolateFields({ data, meta, format: String(data.field) });
+    const partition = interpolateFields({
+      data,
+      meta,
+      format: String(data.field),
+    });
     return `${partition}:${mainId}`;
   }
-  
+
   return mainId;
 };

--- a/src/ids/assembleId.ts
+++ b/src/ids/assembleId.ts
@@ -44,9 +44,7 @@ export const assembleId = function ({
   }
 
   // For backwards compatibility, check if the id structure already starts with field: (to avoid double field prefixing)
-  if (idStructure.startsWith("field:")) {
-    idStructure = idStructure.slice(6);
-  }
+  idStructure = idStructure.replace(/^%field%:/, "");
 
   // Generate the main part of the ID
   const mainId = interpolateFields({ data, meta, format: idStructure });

--- a/src/ids/buildIdStructure.ts
+++ b/src/ids/buildIdStructure.ts
@@ -2,20 +2,17 @@ import { defaults } from "../input/defaults";
 
 export type buildIdStructureType = {
   idParts: string | string[];
-  partition?: string | string[];
   delimiter?: string;
 };
 export const buildIdStructure = function ({
   idParts,
-  partition,
   delimiter = defaults.idDelimiter,
 }: buildIdStructureType): string {
   // % is reserved for field names, escape it
   delimiter = delimiter === "%" ? "\\%" : delimiter;
 
   // Handle the id parts only (field is handled separately in assembleId)
-  const inputArray =
-    typeof idParts === "string" ? [idParts] : idParts;
+  const inputArray = typeof idParts === "string" ? [idParts] : idParts;
 
   // for convenience, user can use just "%fieldName" rather than the full "%fieldName%", this adds the missing percent at the end
   const appendedTrailingPercent = inputArray.map((idComponent) => {

--- a/src/ids/buildIdStructure.ts
+++ b/src/ids/buildIdStructure.ts
@@ -13,21 +13,16 @@ export const buildIdStructure = function ({
   // % is reserved for field names, escape it
   delimiter = delimiter === "%" ? "\\%" : delimiter;
 
-  const partitionAndId =
-    partition === undefined ? [idParts] : [partition, idParts];
-  const structurizedPartitionId = partitionAndId.map((idOrPartition) => {
-    const inputArray =
-      typeof idOrPartition === "string" ? [idOrPartition] : idOrPartition;
+  // Handle the id parts only (field is handled separately in assembleId)
+  const inputArray =
+    typeof idParts === "string" ? [idParts] : idParts;
 
-    // for convenience, user can use just "%fieldName" rather than the full "%fieldName%", this adds the missing percent at the end
-    const appendedTrailingPercent = inputArray.map((idComponent) => {
-      // skip escaped percents
-      const percentCount = (idComponent.match(/(?<!\\)%/g) || []).length;
-      return percentCount % 2 === 0 ? idComponent : idComponent + "%";
-    });
-
-    return appendedTrailingPercent.join(delimiter);
+  // for convenience, user can use just "%fieldName" rather than the full "%fieldName%", this adds the missing percent at the end
+  const appendedTrailingPercent = inputArray.map((idComponent) => {
+    // skip escaped percents
+    const percentCount = (idComponent.match(/(?<!\\)%/g) || []).length;
+    return percentCount % 2 === 0 ? idComponent : idComponent + "%";
   });
 
-  return structurizedPartitionId.join(":");
+  return appendedTrailingPercent.join(delimiter);
 };

--- a/src/ids/buildIdStructure.ts
+++ b/src/ids/buildIdStructure.ts
@@ -14,7 +14,7 @@ export const buildIdStructure = function ({
   // Handle the id parts only (field is handled separately in assembleId)
   const inputArray = typeof idParts === "string" ? [idParts] : idParts;
 
-  // for convenience, user can use just "%fieldName" rather than the full "%fieldName%", this adds the missing percent at the end
+  // for convenience, user can use just "%keyName" rather than the full "%keyName%", this adds the missing percent at the end
   const appendedTrailingPercent = inputArray.map((idComponent) => {
     // skip escaped percents
     const percentCount = (idComponent.match(/(?<!\\)%/g) || []).length;

--- a/src/ids/defaultIdComponents.ts
+++ b/src/ids/defaultIdComponents.ts
@@ -12,7 +12,6 @@ export function defaultIdComponents({
   meta?: DatumMetadata;
 }): {
   defaultIdParts: string[];
-  defaultPartitionParts?: string[];
 } {
   const defaultIdParts = isOccurredData(data)
     ? ["%occurTime%"]
@@ -21,6 +20,5 @@ export function defaultIdComponents({
       : Object.keys(data).map(
           (key) => `%${key.replace(/%/g, String.raw`\%`)}%`,
         );
-  const defaultPartitionParts = "field" in data ? ["%field%"] : undefined;
-  return { defaultIdParts, defaultPartitionParts };
+  return { defaultIdParts };
 }

--- a/src/input/fieldArgs.ts
+++ b/src/input/fieldArgs.ts
@@ -13,7 +13,7 @@ const fieldGroup = fieldArgs.add_argument_group({
   description: "Options for selecting a field",
 });
 fieldGroup.add_argument("field", {
-  help: "what is being tracked",
+  help: "what is being tracked; can use %fieldName% syntax to compose from other data",
   nargs: "?",
 });
 fieldGroup.add_argument("--fieldless", "-F", {

--- a/src/input/fieldArgs.ts
+++ b/src/input/fieldArgs.ts
@@ -13,7 +13,7 @@ const fieldGroup = fieldArgs.add_argument_group({
   description: "Options for selecting a field",
 });
 fieldGroup.add_argument("field", {
-  help: "what is being tracked; can use %fieldName% syntax to compose from other data",
+  help: "what is being tracked; can use %keyName% syntax to compose from other data",
   nargs: "?",
 });
 fieldGroup.add_argument("--fieldless", "-F", {

--- a/src/meta/__test__/addIdAndMetadata.test.ts
+++ b/src/meta/__test__/addIdAndMetadata.test.ts
@@ -123,7 +123,7 @@ describe("addIdAndMetadata", () => {
     const payload = addIdAndMetadata(
       {
         foo: "bar",
-        field: "field",
+        field: "%foo",
         occurTime: { utc: "2023-09-05T11:20:00.000Z", o: 0, tz: "UTC" },
       },
       {
@@ -132,7 +132,7 @@ describe("addIdAndMetadata", () => {
     ) as DatumPayload;
     expect(payload).toMatchObject({
       data: {
-        field: "field",
+        field: "%foo",
         foo: "bar",
         occurTime: { utc: "2023-09-05T11:20:00.000Z", o: 0, tz: "UTC" },
       },
@@ -141,14 +141,14 @@ describe("addIdAndMetadata", () => {
       },
     });
     const hid = payload.meta.humanId;
-    expect(payload._id).toEqual(`field:${hid}`);
+    expect(payload._id).toEqual(`bar:${hid}`);
   });
 
   it("adds id and metadata in a sane and stable way 7", () => {
     const payload = addIdAndMetadata(
       {
         foo: "bar",
-        field: "field",
+        field: "%foo%",
         occurTime: { utc: "2023-09-05T11:20:00.000Z" },
       },
       {
@@ -158,7 +158,7 @@ describe("addIdAndMetadata", () => {
     ) as DatumPayload;
     expect(payload).toMatchObject({
       data: {
-        field: "field",
+        field: "%foo%",
         foo: "bar",
         occurTime: {
           utc: "2023-09-05T11:20:00.000Z",
@@ -169,7 +169,7 @@ describe("addIdAndMetadata", () => {
       },
     });
     const hid = payload.meta.humanId;
-    expect(payload._id).toEqual(`field:2023-09-05T11:20:00.000Z!!!${hid}`);
+    expect(payload._id).toEqual(`bar:2023-09-05T11:20:00.000Z!!!${hid}`);
   });
 
   it("throws an error if the derived id is blank", () => {

--- a/src/meta/__test__/addIdAndMetadata.test.ts
+++ b/src/meta/__test__/addIdAndMetadata.test.ts
@@ -1,6 +1,6 @@
 import { addIdAndMetadata } from "../addIdAndMetadata";
 import { setNow } from "../../__test__/test-utils";
-import { IdError } from "../../errors";
+import { IdError, FieldError } from "../../errors";
 import { toDatumTime } from "../../time/datumTime";
 import { DatumPayload } from "../../documentControl/DatumDocument";
 
@@ -177,6 +177,24 @@ describe("addIdAndMetadata", () => {
     expect(() => addIdAndMetadata({ foo: "bar" }, { idParts: [""] })).toThrow(
       IdError,
     );
+  });
+  
+  it("throws an error if field contains a colon", () => {
+    expect(() => 
+      addIdAndMetadata({ field: "invalid:field" }, {})
+    ).toThrow(FieldError);
+    
+    expect(() => 
+      addIdAndMetadata({}, { field: "invalid:field" })
+    ).toThrow(FieldError);
+    
+    // Test composite field that would generate a field with a colon
+    expect(() =>
+      addIdAndMetadata(
+        { part1: "first", part2: "second" },
+        { field: "%part1%:%part2%" }
+      )
+    ).toThrow(FieldError);
   });
   
   it("handles composite field syntax correctly", () => {

--- a/src/meta/__test__/addIdAndMetadata.test.ts
+++ b/src/meta/__test__/addIdAndMetadata.test.ts
@@ -178,25 +178,25 @@ describe("addIdAndMetadata", () => {
       IdError,
     );
   });
-  
+
   it("throws an error if field contains a colon", () => {
-    expect(() => 
-      addIdAndMetadata({ field: "invalid:field" }, {})
-    ).toThrow(FieldError);
-    
-    expect(() => 
-      addIdAndMetadata({}, { field: "invalid:field" })
-    ).toThrow(FieldError);
-    
+    expect(() => addIdAndMetadata({ field: "invalid:field" }, {})).toThrow(
+      FieldError,
+    );
+
+    expect(() => addIdAndMetadata({}, { field: "invalid:field" })).toThrow(
+      FieldError,
+    );
+
     // Test composite field that would generate a field with a colon
     expect(() =>
       addIdAndMetadata(
         { part1: "first", part2: "second" },
-        { field: "%part1%:%part2%" }
-      )
+        { field: "%part1%:%part2%" },
+      ),
     ).toThrow(FieldError);
   });
-  
+
   it("handles composite field syntax correctly", () => {
     const payload = addIdAndMetadata(
       {
@@ -208,14 +208,14 @@ describe("addIdAndMetadata", () => {
         field: "%prefix%_%state%",
       },
     ) as DatumPayload;
-    
+
     expect(payload.data).toMatchObject({
       prefix: "test",
       state: "active",
       field: "test_active",
       occurTime: { utc: "2023-09-05T11:20:00.000Z" },
     });
-    
+
     expect(payload._id).toEqual("test_active:2023-09-05T11:20:00.000Z");
     expect(payload.meta.idStructure).toEqual("%occurTime%");
   });

--- a/src/meta/addIdAndMetadata.ts
+++ b/src/meta/addIdAndMetadata.ts
@@ -37,12 +37,14 @@ export function addIdAndMetadata<T>(
   }
 
   // Check if specified field parameter contains colon before processing
-  if (args.field && args.field.includes(':')) {
-    throw new FieldError(`Field cannot contain colons (:) as they are used as ID delimiters. Got: "${args.field}"`);
+  if (args.field && args.field.includes(":")) {
+    throw new FieldError(
+      `Field cannot contain colons (:) as they are used as ID delimiters. Got: "${args.field}"`,
+    );
   }
 
   // Process field if it contains % syntax
-  if (args.field && args.field.includes('%')) {
+  if (args.field && args.field.includes("%")) {
     // Create a copy of data to avoid modifying the original
     data = { ...data };
     const processedField = interpolateFields({
@@ -50,18 +52,27 @@ export function addIdAndMetadata<T>(
       meta,
       format: args.field,
     });
-    
+
     // Verify the processed field doesn't contain a colon
-    if (processedField.includes(':')) {
-      throw new FieldError(`Composite field cannot contain colons (:) as they are used as ID delimiters. Got: "${processedField}" from template "${args.field}"`);
+    if (processedField.includes(":")) {
+      throw new FieldError(
+        `Composite field cannot contain colons (:) as they are used as ID delimiters. Got: "${processedField}" from template "${args.field}"`,
+      );
     }
-    
+
     data.field = processedField;
   }
-  
+
   // Check if field contains a colon, which would break ID parsing
-  if ("field" in data && data.field && typeof data.field === "string" && data.field.includes(':')) {
-    throw new FieldError(`Field cannot contain colons (:) as they are used as ID delimiters. Got: "${data.field}"`);
+  if (
+    "field" in data &&
+    data.field &&
+    typeof data.field === "string" &&
+    data.field.includes(":")
+  ) {
+    throw new FieldError(
+      `Field cannot contain colons (:) as they are used as ID delimiters. Got: "${data.field}"`,
+    );
   }
 
   const payload: EitherPayload<T> =
@@ -90,11 +101,11 @@ export function addIdAndMetadata<T>(
     payload,
     idStructure: mainIdStructure,
   });
-  
+
   if (_id === "") {
     throw new IdError("Provided or derived _id is blank");
   }
-  
+
   const idPayload = { _id, ...payload };
   return idPayload;
 }

--- a/src/output/output.ts
+++ b/src/output/output.ts
@@ -65,10 +65,22 @@ function formatAllTimes(doc: EitherPayload): AllTimes {
   return times;
 }
 
-function formatField(field?: string): string | undefined {
+function formatField(field?: string, doc?: EitherPayload): string | undefined {
   if (field === undefined) {
     return undefined;
   }
+  
+  // If field contains % syntax and we have document data, interpolate it
+  if (field.includes("%") && doc) {
+    const { data, meta } = pullOutData(doc);
+    const interpolatedField = interpolateFields({
+      data,
+      meta,
+      format: field,
+    });
+    return fieldChalk({ field: interpolatedField })(interpolatedField);
+  }
+  
   return fieldChalk({ field })(field);
 }
 
@@ -231,7 +243,7 @@ export function extractFormatted(
     id: doc._id ? chalk.gray(doc._id) : undefined,
     hid: meta?.humanId ? color(meta.humanId.slice(0, 5)) : undefined,
     time: formatAllTimes(doc),
-    field: formatField(data.field),
+    field: formatField(data.field, doc),
     state: formatState(data),
     dur: formatDuration(data.dur),
   };

--- a/src/output/output.ts
+++ b/src/output/output.ts
@@ -69,7 +69,7 @@ function formatField(field?: string, doc?: EitherPayload): string | undefined {
   if (field === undefined) {
     return undefined;
   }
-  
+
   // If field contains % syntax and we have document data, interpolate it
   if (field.includes("%") && doc) {
     const { data, meta } = pullOutData(doc);
@@ -80,7 +80,7 @@ function formatField(field?: string, doc?: EitherPayload): string | undefined {
     });
     return fieldChalk({ field: interpolatedField })(interpolatedField);
   }
-  
+
   return fieldChalk({ field })(field);
 }
 

--- a/src/utils/__test__/__snapshots__/changeDatumCommand.test.ts.snap
+++ b/src/utils/__test__/__snapshots__/changeDatumCommand.test.ts.snap
@@ -24,7 +24,7 @@ exports[`changing from one command to another addCmd can become a start command 
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -58,7 +58,7 @@ exports[`changing from one command to another addCmd can become a switch command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -92,7 +92,7 @@ exports[`changing from one command to another addCmd can become an end command 1
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -125,7 +125,7 @@ exports[`changing from one command to another addCmd can become an occur command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -159,7 +159,7 @@ exports[`changing from one command to another endCmd can become a switch command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -193,7 +193,7 @@ exports[`changing from one command to another endCmd can become an occur command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -227,7 +227,7 @@ exports[`changing from one command to another endCmd can become start command 1`
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -261,7 +261,7 @@ exports[`changing from one command to another occurCmd can become a start comman
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -295,7 +295,7 @@ exports[`changing from one command to another occurCmd can become a switch comma
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -329,7 +329,7 @@ exports[`changing from one command to another occurCmd can become an end command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -362,7 +362,7 @@ exports[`changing from one command to another occurCmd doesn't require a duratio
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -396,7 +396,7 @@ exports[`changing from one command to another startCmd can become a switch comma
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -430,7 +430,7 @@ exports[`changing from one command to another startCmd can become an end command
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -464,7 +464,7 @@ exports[`changing from one command to another startCmd can become an occur comma
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -498,7 +498,7 @@ exports[`changing from one command to another switchCmd can become a start comma
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -532,7 +532,7 @@ exports[`changing from one command to another switchCmd can become an end comman
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",
@@ -566,7 +566,7 @@ exports[`changing from one command to another switchCmd can become an occur comm
       "utc": "2023-12-21T14:00:00.000Z",
     },
     "humanId": "elfuv1633zeysuyhc0l9ss",
-    "idStructure": "%field%:%occurTime%",
+    "idStructure": "%occurTime%",
     "modifyTime": {
       "o": 0,
       "tz": "UTC",


### PR DESCRIPTION
## Summary
- Implement GitHub issue #903
- Allow field to be composed from other data using % syntax
- Always use field as partition in the ID
- Remove the partition option

## Test plan
- Added tests for composite field syntax
- Updated existing tests to match the new field partition behavior
- All tests are passing

🤖 Generated with [Claude Code](https://claude.ai/code)