### PR TITLE
Remove outlines on svg blocks

### DIFF
--- a/src/commands/__test__/__snapshots__/dayviewCmd.test.ts.snap
+++ b/src/commands/__test__/__snapshots__/dayviewCmd.test.ts.snap
@@ -48,7 +48,7 @@ exports[`dayview consistently generates a sample morning svg 1`] = `
                         <rect data-hover-text="Field: text
 State: fiction_book
 Time: 08:40 - 09:10
-Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="fiction_book" data-field="text" height="12" width="19.08333355420524" y="0" x="330.7777816062243" fill="#06de5f" class="text fiction_book block"/>
+Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="fiction_book" data-field="text" height="12" width="20" y="0" x="330.7777816062243" stroke-width="0" fill="#06de5f" class="text fiction_book block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -81,12 +81,12 @@ Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08
                     <svg height="12" width="916" y="21.72283353842795" x="0" preserveAspectRatio="none" viewBox="0 0 916 12" class="project">
                         <defs>
                             <pattern patternTransform="rotate(45)" height="12" width="16" patternUnits="userSpaceOnUse" id="stripe-pattern-emails-tasks-419.8333381925155">
-                                <rect fill="#af67ca" height="36" width="8" y="-12" x="0"/>
-                                <rect fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
+                                <rect stroke-width="0" fill="#af67ca" height="36" width="8" y="-12" x="0"/>
+                                <rect stroke-width="0" fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
                             </pattern>
                             <pattern patternTransform="rotate(45)" height="12" width="16" patternUnits="userSpaceOnUse" id="stripe-pattern-emails-tasks-438.91667174672074">
-                                <rect fill="#af67ca" height="36" width="8" y="-12" x="0"/>
-                                <rect fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
+                                <rect stroke-width="0" fill="#af67ca" height="36" width="8" y="-12" x="0"/>
+                                <rect stroke-width="0" fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
                             </pattern>
                             <style>
                                 .popover {
@@ -108,19 +108,19 @@ Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08
                         <rect data-hover-text="Field: project
 State: german
 Time: 08:40 - 09:10
-Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="german" data-field="project" height="12" width="19.08333355420524" y="0" x="330.7777816062243" fill="#a6d414" class="project german block"/>
+Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="german" data-field="project" height="12" width="20" y="0" x="330.7777816062243" stroke-width="0" fill="#a6d414" class="project german block"/>
                         <rect data-hover-text="Field: project
 State: emails, tasks
 Time: 11:00 - 11:20
-Duration: 20m" data-end-time="2024-11-20T11:20:00.000Z" data-time="2024-11-20T11:00:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="12.72222236947016" y="0" x="419.8333381925155" fill="url(#stripe-pattern-emails-tasks-419.8333381925155)" class="project multi-state block"/>
+Duration: 20m" data-end-time="2024-11-20T11:20:00.000Z" data-time="2024-11-20T11:00:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="13" y="0" x="419.8333381925155" stroke-width="0" fill="url(#stripe-pattern-emails-tasks-419.8333381925155)" class="project multi-state block"/>
                         <rect data-hover-text="Field: project
 State: meeting
 Time: 11:20 - 11:30
-Duration: 10m" data-end-time="2024-11-20T11:30:00.000Z" data-time="2024-11-20T11:20:00.000Z" data-state="meeting" data-field="project" height="12" width="6.36111118473508" y="0" x="432.55556056198566" fill="#d48788" class="project meeting block"/>
+Duration: 10m" data-end-time="2024-11-20T11:30:00.000Z" data-time="2024-11-20T11:20:00.000Z" data-state="meeting" data-field="project" height="12" width="7" y="0" x="432.55556056198566" stroke-width="0" fill="#d48788" class="project meeting block"/>
                         <rect data-hover-text="Field: project
 State: emails, tasks
 Time: 11:30 - 11:45
-Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11:30:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="9.541666777102648" y="0" x="438.91667174672074" fill="url(#stripe-pattern-emails-tasks-438.91667174672074)" class="project multi-state block"/>
+Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11:30:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="10" y="0" x="438.91667174672074" stroke-width="0" fill="url(#stripe-pattern-emails-tasks-438.91667174672074)" class="project multi-state block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -172,11 +172,11 @@ Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11
                         <rect data-hover-text="Field: stretch
 State: true
 Time: 09:30 - 09:37
-Duration: 7m" data-end-time="2024-11-20T09:37:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="true" data-field="stretch" height="12" width="4.452777829314584" y="0" x="362.5833375298997" fill="#7e8494" class="stretch true block"/>
+Duration: 7m" data-end-time="2024-11-20T09:37:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="true" data-field="stretch" height="12" width="5" y="0" x="362.5833375298997" stroke-width="0" fill="#7e8494" class="stretch true block"/>
                         <rect data-hover-text="Field: stretch
 State: true
 Time: 10:07 - 10:15
-Duration: 8m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T10:07:00.000Z" data-state="true" data-field="stretch" height="12" width="5.088888947788064" y="0" x="386.11944891341955" fill="#7e8494" class="stretch true block"/>
+Duration: 8m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T10:07:00.000Z" data-state="true" data-field="stretch" height="12" width="6" y="0" x="386.11944891341955" stroke-width="0" fill="#7e8494" class="stretch true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -279,7 +279,7 @@ Time: 10:18" data-time="2024-11-20T10:18:00.000Z" data-state="true" data-field="
                         <rect data-hover-text="Field: run
 State: true
 Time: 09:37 - 10:07
-Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09:37:00.000Z" data-state="true" data-field="run" height="12" width="19.08333355420524" y="0" x="367.0361153592143" fill="#a53108" class="run true block"/>
+Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09:37:00.000Z" data-state="true" data-field="run" height="12" width="20" y="0" x="367.0361153592143" stroke-width="0" fill="#a53108" class="run true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -331,7 +331,7 @@ Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09
                         <rect data-hover-text="Field: sleep
 State: true
 Time: 00:00 - 08:30
-Duration: 8h 30m" data-end-time="2024-11-20T08:30:00.000Z" data-time="2024-11-20T00:00:00.000Z" data-state="true" data-field="sleep" height="12" width="324.41667042148924" y="0" x="0" fill="#c9fab3" class="sleep true block"/>
+Duration: 8h 30m" data-end-time="2024-11-20T08:30:00.000Z" data-time="2024-11-20T00:00:00.000Z" data-state="true" data-field="sleep" height="12" width="325" y="0" x="0" stroke-width="0" fill="#c9fab3" class="sleep true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -441,19 +441,19 @@ Time: 11:00" data-time="2024-11-20T11:00:00.000Z" data-state="true" data-field="
                         <rect data-hover-text="Field: environment
 State: outside
 Time: 09:30 - 10:15
-Duration: 45m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="outside" data-field="environment" height="12" width="28.625000331307888" y="0" x="362.5833375298997" fill="#c30163" class="environment outside block"/>
+Duration: 45m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="outside" data-field="environment" height="12" width="29" y="0" x="362.5833375298997" stroke-width="0" fill="#c30163" class="environment outside block"/>
                         <rect data-hover-text="Field: environment
 State: home
 Time: 10:15 - 10:25
-Duration: 10m" data-end-time="2024-11-20T10:25:00.000Z" data-time="2024-11-20T10:15:00.000Z" data-state="home" data-field="environment" height="12" width="6.36111118473508" y="0" x="391.2083378612076" fill="#106a6c" class="environment home block"/>
+Duration: 10m" data-end-time="2024-11-20T10:25:00.000Z" data-time="2024-11-20T10:15:00.000Z" data-state="home" data-field="environment" height="12" width="7" y="0" x="391.2083378612076" stroke-width="0" fill="#106a6c" class="environment home block"/>
                         <rect data-hover-text="Field: environment
 State: outside
 Time: 10:25 - 10:30
-Duration: 5m" data-end-time="2024-11-20T10:30:00.000Z" data-time="2024-11-20T10:25:00.000Z" data-state="outside" data-field="environment" height="12" width="3.1805555923675684" y="0" x="397.5694490459427" fill="#c30163" class="environment outside block"/>
+Duration: 5m" data-end-time="2024-11-20T10:30:00.000Z" data-time="2024-11-20T10:25:00.000Z" data-state="outside" data-field="environment" height="12" width="4" y="0" x="397.5694490459427" stroke-width="0" fill="#c30163" class="environment outside block"/>
                         <rect data-hover-text="Field: environment
 State: home
 Time: 10:30 - 23:59
-Duration: 13h 30m" data-end-time="2024-11-20T23:59:59.999Z" data-time="2024-11-20T10:30:00.000Z" data-state="home" data-field="environment" height="12" width="515.2499953616898" y="0" x="400.75000463831026" fill="#106a6c" class="environment home block"/>
+Duration: 13h 30m" data-end-time="2024-11-20T23:59:59.999Z" data-time="2024-11-20T10:30:00.000Z" data-state="home" data-field="environment" height="12" width="516" y="0" x="400.75000463831026" stroke-width="0" fill="#106a6c" class="environment home block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element

--- a/src/commands/__test__/__snapshots__/sample_morning.svg
+++ b/src/commands/__test__/__snapshots__/sample_morning.svg
@@ -45,7 +45,7 @@
                         <rect data-hover-text="Field: text
 State: fiction_book
 Time: 08:40 - 09:10
-Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="fiction_book" data-field="text" height="12" width="19.08333355420524" y="0" x="330.7777816062243" fill="#06de5f" class="text fiction_book block"/>
+Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="fiction_book" data-field="text" height="12" width="20" y="0" x="330.7777816062243" stroke-width="0" fill="#06de5f" class="text fiction_book block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -78,12 +78,12 @@ Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08
                     <svg height="12" width="916" y="21.72283353842795" x="0" preserveAspectRatio="none" viewBox="0 0 916 12" class="project">
                         <defs>
                             <pattern patternTransform="rotate(45)" height="12" width="16" patternUnits="userSpaceOnUse" id="stripe-pattern-emails-tasks-419.8333381925155">
-                                <rect fill="#af67ca" height="36" width="8" y="-12" x="0"/>
-                                <rect fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
+                                <rect stroke-width="0" fill="#af67ca" height="36" width="8" y="-12" x="0"/>
+                                <rect stroke-width="0" fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
                             </pattern>
                             <pattern patternTransform="rotate(45)" height="12" width="16" patternUnits="userSpaceOnUse" id="stripe-pattern-emails-tasks-438.91667174672074">
-                                <rect fill="#af67ca" height="36" width="8" y="-12" x="0"/>
-                                <rect fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
+                                <rect stroke-width="0" fill="#af67ca" height="36" width="8" y="-12" x="0"/>
+                                <rect stroke-width="0" fill="#2cb1ad" height="36" width="8" y="-12" x="8"/>
                             </pattern>
                             <style>
                                 .popover {
@@ -105,19 +105,19 @@ Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08
                         <rect data-hover-text="Field: project
 State: german
 Time: 08:40 - 09:10
-Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="german" data-field="project" height="12" width="19.08333355420524" y="0" x="330.7777816062243" fill="#a6d414" class="project german block"/>
+Duration: 30m" data-end-time="2024-11-20T09:10:00.000Z" data-time="2024-11-20T08:40:00.000Z" data-state="german" data-field="project" height="12" width="20" y="0" x="330.7777816062243" stroke-width="0" fill="#a6d414" class="project german block"/>
                         <rect data-hover-text="Field: project
 State: emails, tasks
 Time: 11:00 - 11:20
-Duration: 20m" data-end-time="2024-11-20T11:20:00.000Z" data-time="2024-11-20T11:00:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="12.72222236947016" y="0" x="419.8333381925155" fill="url(#stripe-pattern-emails-tasks-419.8333381925155)" class="project multi-state block"/>
+Duration: 20m" data-end-time="2024-11-20T11:20:00.000Z" data-time="2024-11-20T11:00:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="13" y="0" x="419.8333381925155" stroke-width="0" fill="url(#stripe-pattern-emails-tasks-419.8333381925155)" class="project multi-state block"/>
                         <rect data-hover-text="Field: project
 State: meeting
 Time: 11:20 - 11:30
-Duration: 10m" data-end-time="2024-11-20T11:30:00.000Z" data-time="2024-11-20T11:20:00.000Z" data-state="meeting" data-field="project" height="12" width="6.36111118473508" y="0" x="432.55556056198566" fill="#d48788" class="project meeting block"/>
+Duration: 10m" data-end-time="2024-11-20T11:30:00.000Z" data-time="2024-11-20T11:20:00.000Z" data-state="meeting" data-field="project" height="12" width="7" y="0" x="432.55556056198566" stroke-width="0" fill="#d48788" class="project meeting block"/>
                         <rect data-hover-text="Field: project
 State: emails, tasks
 Time: 11:30 - 11:45
-Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11:30:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="9.541666777102648" y="0" x="438.91667174672074" fill="url(#stripe-pattern-emails-tasks-438.91667174672074)" class="project multi-state block"/>
+Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11:30:00.000Z" data-state="emails, tasks" data-field="project" height="12" width="10" y="0" x="438.91667174672074" stroke-width="0" fill="url(#stripe-pattern-emails-tasks-438.91667174672074)" class="project multi-state block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -169,11 +169,11 @@ Duration: 15m" data-end-time="2024-11-20T11:45:00.000Z" data-time="2024-11-20T11
                         <rect data-hover-text="Field: stretch
 State: true
 Time: 09:30 - 09:37
-Duration: 7m" data-end-time="2024-11-20T09:37:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="true" data-field="stretch" height="12" width="4.452777829314584" y="0" x="362.5833375298997" fill="#7e8494" class="stretch true block"/>
+Duration: 7m" data-end-time="2024-11-20T09:37:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="true" data-field="stretch" height="12" width="5" y="0" x="362.5833375298997" stroke-width="0" fill="#7e8494" class="stretch true block"/>
                         <rect data-hover-text="Field: stretch
 State: true
 Time: 10:07 - 10:15
-Duration: 8m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T10:07:00.000Z" data-state="true" data-field="stretch" height="12" width="5.088888947788064" y="0" x="386.11944891341955" fill="#7e8494" class="stretch true block"/>
+Duration: 8m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T10:07:00.000Z" data-state="true" data-field="stretch" height="12" width="6" y="0" x="386.11944891341955" stroke-width="0" fill="#7e8494" class="stretch true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -276,7 +276,7 @@ Time: 10:18" data-time="2024-11-20T10:18:00.000Z" data-state="true" data-field="
                         <rect data-hover-text="Field: run
 State: true
 Time: 09:37 - 10:07
-Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09:37:00.000Z" data-state="true" data-field="run" height="12" width="19.08333355420524" y="0" x="367.0361153592143" fill="#a53108" class="run true block"/>
+Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09:37:00.000Z" data-state="true" data-field="run" height="12" width="20" y="0" x="367.0361153592143" stroke-width="0" fill="#a53108" class="run true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -328,7 +328,7 @@ Duration: 30m" data-end-time="2024-11-20T10:07:00.000Z" data-time="2024-11-20T09
                         <rect data-hover-text="Field: sleep
 State: true
 Time: 00:00 - 08:30
-Duration: 8h 30m" data-end-time="2024-11-20T08:30:00.000Z" data-time="2024-11-20T00:00:00.000Z" data-state="true" data-field="sleep" height="12" width="324.41667042148924" y="0" x="0" fill="#c9fab3" class="sleep true block"/>
+Duration: 8h 30m" data-end-time="2024-11-20T08:30:00.000Z" data-time="2024-11-20T00:00:00.000Z" data-state="true" data-field="sleep" height="12" width="325" y="0" x="0" stroke-width="0" fill="#c9fab3" class="sleep true block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element
@@ -438,19 +438,19 @@ Time: 11:00" data-time="2024-11-20T11:00:00.000Z" data-state="true" data-field="
                         <rect data-hover-text="Field: environment
 State: outside
 Time: 09:30 - 10:15
-Duration: 45m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="outside" data-field="environment" height="12" width="28.625000331307888" y="0" x="362.5833375298997" fill="#c30163" class="environment outside block"/>
+Duration: 45m" data-end-time="2024-11-20T10:15:00.000Z" data-time="2024-11-20T09:30:00.000Z" data-state="outside" data-field="environment" height="12" width="29" y="0" x="362.5833375298997" stroke-width="0" fill="#c30163" class="environment outside block"/>
                         <rect data-hover-text="Field: environment
 State: home
 Time: 10:15 - 10:25
-Duration: 10m" data-end-time="2024-11-20T10:25:00.000Z" data-time="2024-11-20T10:15:00.000Z" data-state="home" data-field="environment" height="12" width="6.36111118473508" y="0" x="391.2083378612076" fill="#106a6c" class="environment home block"/>
+Duration: 10m" data-end-time="2024-11-20T10:25:00.000Z" data-time="2024-11-20T10:15:00.000Z" data-state="home" data-field="environment" height="12" width="7" y="0" x="391.2083378612076" stroke-width="0" fill="#106a6c" class="environment home block"/>
                         <rect data-hover-text="Field: environment
 State: outside
 Time: 10:25 - 10:30
-Duration: 5m" data-end-time="2024-11-20T10:30:00.000Z" data-time="2024-11-20T10:25:00.000Z" data-state="outside" data-field="environment" height="12" width="3.1805555923675684" y="0" x="397.5694490459427" fill="#c30163" class="environment outside block"/>
+Duration: 5m" data-end-time="2024-11-20T10:30:00.000Z" data-time="2024-11-20T10:25:00.000Z" data-state="outside" data-field="environment" height="12" width="4" y="0" x="397.5694490459427" stroke-width="0" fill="#c30163" class="environment outside block"/>
                         <rect data-hover-text="Field: environment
 State: home
 Time: 10:30 - 23:59
-Duration: 13h 30m" data-end-time="2024-11-20T23:59:59.999Z" data-time="2024-11-20T10:30:00.000Z" data-state="home" data-field="environment" height="12" width="515.2499953616898" y="0" x="400.75000463831026" fill="#106a6c" class="environment home block"/>
+Duration: 13h 30m" data-end-time="2024-11-20T23:59:59.999Z" data-time="2024-11-20T10:30:00.000Z" data-state="home" data-field="environment" height="12" width="516" y="0" x="400.75000463831026" stroke-width="0" fill="#106a6c" class="environment home block"/>
                         <script type="text/javascript">
                             (function() {
       // Create popover element

--- a/src/dayview/allFieldsSvg.ts
+++ b/src/dayview/allFieldsSvg.ts
@@ -36,7 +36,7 @@ export async function allFieldsSvg(args: AllFieldsSvgType) {
 
       const y1 = pY * height;
       const zIndex = spec.zIndex ?? pY;
-      const fieldHeight = pHeight * height;
+      const fieldHeight = Math.ceil(pHeight * height);
       return { field, y1, fieldHeight, zIndex };
     })
     .sort((a, b) => a.zIndex - b.zIndex);

--- a/src/dayview/fieldSvgBlocks.ts
+++ b/src/dayview/fieldSvgBlocks.ts
@@ -142,7 +142,7 @@ export async function fieldSvgBlocks(args: FieldSvgBlocksType) {
     const hoverText = `Field: ${field}\nState: ${stateText}\nTime: ${formatTime(startTime)} - ${formatTime(endTime)}\nDuration: ${durationText}`;
 
     // Calculate dimensions
-    const blockWidth = timeScale(next.time) - timeScale(curr.time);
+    const blockWidth = Math.ceil(timeScale(next.time) - timeScale(curr.time));
     const x = timeScale(curr.time);
 
     let fillPattern: string;
@@ -172,7 +172,8 @@ export async function fieldSvgBlocks(args: FieldSvgBlocksType) {
           .attr("y", -height)
           .attr("width", stripeWidth)
           .attr("height", height * 3)
-          .attr("fill", color);
+          .attr("fill", color)
+          .attr("stroke-width", 0);
       });
 
       className = `${field} multi-state block`;
@@ -182,6 +183,7 @@ export async function fieldSvgBlocks(args: FieldSvgBlocksType) {
       .append("rect")
       .attr("class", className)
       .attr("fill", fillPattern)
+      .attr("stroke-width", 0)
       .attr("x", x)
       .attr("y", 0)
       .attr("width", blockWidth)


### PR DESCRIPTION
Data is more continuous, so the harsh separators look off
This removes the stroke width and also fills out width and height of blocks to prevent gaps from appearing between contiguous events