### PR TITLE
Move duration argument to be after required and optional arguments

### DIFF
--- a/src/commands/__test__/endCmd.test.ts
+++ b/src/commands/__test__/endCmd.test.ts
@@ -82,22 +82,22 @@ describe("endCmd", () => {
 
   it("can skip the duration if the duration is given as . or ''", async () => {
     restoreNow();
-    const doc = await endCmd("field -k optional= . 50");
-    const doc2 = await endCmd("field -k optional= '' 50");
-    expect(doc.data).toMatchObject({ field: "field", optional: 50 });
+    const doc = await endCmd("field -k optional= 50 . abc=123");
+    const doc2 = await endCmd("field -k optional= 50 '' abc=123");
+    expect(doc.data).toMatchObject({ field: "field", optional: 50, abc: 123 });
     expect(doc.data).not.toHaveProperty("dur");
-    expect(doc2.data).toMatchObject({ field: "field", optional: 50 });
+    expect(doc2.data).toMatchObject({ field: "field", optional: 50, abc: 123 });
     expect(doc2.data).not.toHaveProperty("dur");
   });
 
   it("throws an error if the duration supplied is invalid", async () => {
-    await expect(endCmd("field -k optional= 30asd")).rejects.toThrow(
+    await expect(endCmd("field -k optional= . 30asd")).rejects.toThrow(
       BadDurationError,
     );
   });
 
   it("still assigns a state of false even with required keys and duration comes before keys", async () => {
-    const doc = await endCmd("field 30 reqVal1 -k req1");
+    const doc = await endCmd("field reqVal1 30 -k req1");
     expect(doc.data).toMatchObject({
       field: "field",
       dur: "PT30M",

--- a/src/commands/__test__/startCmd.test.ts
+++ b/src/commands/__test__/startCmd.test.ts
@@ -92,8 +92,8 @@ describe("startCmd", () => {
   it("can skip the duration if the duration is given as . or ''", async () => {
     // TODO: rewrite this test as a string based call;
     restoreNow();
-    const doc = await startCmd("field -k optional= . 50");
-    const doc2 = await startCmd("field -k optional= '' 50");
+    const doc = await startCmd("field -k optional= 50 .");
+    const doc2 = await startCmd("field -k optional= 50 ''");
     expect(doc.data).toMatchObject({ field: "field", optional: 50 });
     expect(doc.data).not.toHaveProperty("dur");
     expect(doc2.data).toMatchObject({ field: "field", optional: 50 });
@@ -101,13 +101,13 @@ describe("startCmd", () => {
   });
 
   it("throws an error if the duration supplied is invalid", async () => {
-    await expect(startCmd("field -k optional= 30asd")).rejects.toThrow(
+    await expect(startCmd("field -k optional= . 30asd")).rejects.toThrow(
       BadDurationError,
     );
   });
 
-  it("still assigns a state of true even with required keys, and duration comes before required keys", async () => {
-    const doc = await startCmd("field 30 reqVal1 -k req1");
+  it("still assigns a state of true even with required keys, and duration comes after required keys", async () => {
+    const doc = await startCmd("field reqVal1 30 -k req1");
     expect(doc.data).toMatchObject({
       field: "field",
       dur: "PT30M",

--- a/src/commands/__test__/switchCmd.test.ts
+++ b/src/commands/__test__/switchCmd.test.ts
@@ -152,8 +152,8 @@ describe("switchCmd", () => {
   it("can skip the duration if the duration is given as . or ''", async () => {
     // TODO: rewrite this test as a string based call;
     restoreNow();
-    const doc = await switchCmd("project household -k optional= . 50");
-    const doc2 = await switchCmd("project household -k optional= '' 50");
+    const doc = await switchCmd("project household -k optional= 50 .");
+    const doc2 = await switchCmd("project household -k optional= 50 ''");
     expect(doc.data).toMatchObject({ field: "project", optional: 50 });
     expect(doc.data).not.toHaveProperty("dur");
     expect(doc2.data).toMatchObject({ field: "project", optional: 50 });
@@ -178,7 +178,7 @@ describe("switchCmd", () => {
 
   it("handles both required and optional keys for complex state correctly", async () => {
     const doc = await switchCmd(
-      "book -k .title -k .author -k .genre= . 5 'the wind in the willows' 'kenneth grahame' fiction",
+      "book -k .title -k .author -k .genre= . 'the wind in the willows' 'kenneth grahame' fiction 5",
     );
 
     expect(doc.data).toMatchObject({
@@ -194,7 +194,7 @@ describe("switchCmd", () => {
 
   it("handles dot syntax required and optional keys correctly", async () => {
     const doc = await switchCmd(
-      "consume -k .medium -k .title= -k .author= .medium=text book_fiction . title author",
+      "consume -k .medium -k .title= -k .author= .medium=text book_fiction title author",
     );
     expect(doc.data).toMatchObject({
       field: "consume",

--- a/src/commands/switchCmd.ts
+++ b/src/commands/switchCmd.ts
@@ -59,6 +59,7 @@ export async function switchCmd(
     "duration",
     "dur=",
     args.moment || args.omitTimestamp,
+    true,
   );
   flexiblePositional(args, "state", "state=true");
   args.cmdData ??= {};

--- a/src/input/__test__/flexiblePositional.test.ts
+++ b/src/input/__test__/flexiblePositional.test.ts
@@ -55,4 +55,17 @@ describe("flexiblePositional", () => {
     expect(args2).not.toHaveProperty("data");
     expect(args2).not.toHaveProperty("keys");
   });
+
+  it("can also add the key after other args", () => {
+    const args: DataArgs & { field: string } = {
+      data: ["arg1", "arg2"],
+      field: "fieldArg",
+      keys: ["key1", "key2"],
+    };
+    flexiblePositional(args, "field", "field", false, true);
+    expect(args).toEqual({
+      data: ["fieldArg", "arg1", "arg2"],
+      keys: ["key1", "key2", "field"],
+    });
+  });
 });

--- a/src/input/flexiblePositional.ts
+++ b/src/input/flexiblePositional.ts
@@ -9,6 +9,7 @@ export function flexiblePositional<T extends DataArgs, K extends keyof T>(
   argName: K,
   keyName: string,
   skipKey?: boolean,
+  afterOtherArgs?: boolean,
 ): void {
   keyName ??= String(argName);
   if (args[argName] === undefined) {
@@ -17,7 +18,11 @@ export function flexiblePositional<T extends DataArgs, K extends keyof T>(
 
   if (!skipKey) {
     args.keys ??= [];
-    args.keys.unshift(keyName);
+    if (afterOtherArgs) {
+      args.keys.push(keyName);
+    } else {
+      args.keys.unshift(keyName);
+    }
   }
 
   args.data ??= [];

--- a/src/utils/__test__/changeDatumCommand.test.ts
+++ b/src/utils/__test__/changeDatumCommand.test.ts
@@ -465,7 +465,7 @@ describe("changing from one command to another", () => {
 
     it("can become an occur command", async () => {
       expect(
-        await startCmd("field 30 -k opt1= key=val optVal occur"),
+        await startCmd("field -k opt1= key=val optVal 30 occur"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -473,7 +473,7 @@ describe("changing from one command to another", () => {
 
     it("can become an end command", async () => {
       expect(
-        await startCmd("field -k opt1= 30 key=val optVal end"),
+        await startCmd("field -k opt1= key=val optVal 30 end"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -481,7 +481,7 @@ describe("changing from one command to another", () => {
 
     it("can become a switch command", async () => {
       expect(
-        await startCmd("field -k opt1= 5m30s key=val optVal switch stateName"),
+        await startCmd("field -k opt1= key=val optVal 5m30s switch stateName"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -497,7 +497,7 @@ describe("changing from one command to another", () => {
 
     it("can become an occur command", async () => {
       expect(
-        await endCmd("field -k opt1= 30 key=val optVal occur"),
+        await endCmd("field -k opt1= key=val optVal 30 occur"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -505,7 +505,7 @@ describe("changing from one command to another", () => {
 
     it("can become start command", async () => {
       expect(
-        await endCmd("field -k opt1= 30 key=val optVal start"),
+        await endCmd("field -k opt1= key=val optVal 30 start"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -513,7 +513,7 @@ describe("changing from one command to another", () => {
 
     it("can become a switch command", async () => {
       expect(
-        await endCmd("field -k opt1= 5m30s key=val optVal switch stateName"),
+        await endCmd("field -k opt1= key=val optVal 5m30s switch stateName"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -529,7 +529,7 @@ describe("changing from one command to another", () => {
 
     it("can become an occur command", async () => {
       expect(
-        await switchCmd("field -k opt1= someState 30 key=val optVal occur"),
+        await switchCmd("field -k opt1= someState key=val optVal 30 occur"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -537,7 +537,7 @@ describe("changing from one command to another", () => {
 
     it("can become an end command", async () => {
       expect(
-        await switchCmd("field -k opt1= someState 30 key=val optVal end"),
+        await switchCmd("field -k opt1= someState key=val optVal 30 end"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });
@@ -545,7 +545,7 @@ describe("changing from one command to another", () => {
 
     it("can become a start command", async () => {
       expect(
-        await switchCmd("field -k opt1= someState 5m30s key=val optVal start"),
+        await switchCmd("field -k opt1= someState key=val optVal 5m30s start"),
       ).toMatchSnapshot({
         _rev: expect.any(String),
       });


### PR DESCRIPTION
It was kind of an awkward anti-pattern to have to put . for duration before some required arguments for an aliases command, but still after state. It didn't feel consistent. So this moves the duration to after all the specified key args

BREAKING CHANGE